### PR TITLE
astropy-iers-data 0.2024.6.3.0.31.14

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,19 +10,19 @@ source:
   sha256: e6d0b43eedadc670c8c30623157614e329f4f255884f7e52cb19bdad48df9899
 
 build:
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  skip: True  # [py<38]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
 
 requirements:
   host:
-    - python >=3.8
+    - python
     - setuptools
     - setuptools-scm
     - wheel
     - pip
   run:
-    - python >=3.8
+    - python
 
 test:
   imports:
@@ -35,8 +35,15 @@ test:
 about:
   home: https://github.com/astropy/astropy-iers-data/
   summary: IERS Earth Rotation and Leap Second tables for the astropy core package
+  description: |
+    The iers package provides access to the tables provided by the International Earth Rotation
+    and Reference Systems (IERS) service, in particular the Earth Orientation data allowing
+    interpolation of published UT1-UTC and polar motion values for given times.
   license: BSD-3-Clause
   license_file: LICENSE.rst
+  license_family: BSD
+  doc_url: https://docs.astropy.org/en/latest/utils/iers.html
+  dev_url: https://github.com/astropy/astropy-iers-data/
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-5014](https://anaconda.atlassian.net/browse/PKG-5014)[PKG-5014](https://anaconda.atlassian.net/browse/PKG-5014)
- [Upstream repository](https://github.com/astropy/astropy-iers-data/tree/v0.2024.06.03.00.31.14)
- [Upstream changelog/diff](https://github.com/astropy/astropy-iers-data/compare/v0.2024.05.27.00.30.08...v0.2024.06.03.00.31.14)
- Relevant dependency PRs:
  - https://github.com/AnacondaRecipes/astropy-feedstock/pull/17

### Explanation of changes:

- Initial upload
- Remove noarch
- Recipe cleanup/Linter fixes

[PKG-5014]: https://anaconda.atlassian.net/browse/PKG-5014?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PKG-5014]: https://anaconda.atlassian.net/browse/PKG-5014?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ