### PR TITLE
Update recipe

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "astropy-iers-data" %}
-{% set version = "0.2024.6.3.0.31.14" %}
+{% set version = "0.2024.9.2.0.33.23" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
-  sha256: e6d0b43eedadc670c8c30623157614e329f4f255884f7e52cb19bdad48df9899
+  sha256: 50a5dade609ed6b9791a04f9da98184846b363e2fd0e36d62690c28c0a2c5114
 
 build:
   skip: True  # [py<38]


### PR DESCRIPTION
astropy-iers-data 0.2024.9.2.0.33.23

**Destination channel:** defaults

### Links

- [PKG-5631](https://anaconda.atlassian.net/browse/PKG-5631) 
- [Upstream repository](https://github.com/astropy/astropy-iers-data/tree/v0.2024.09.02.00.33.23)
- Relevant dependency PRs:
  - [`astropy`](https://github.com/AnacondaRecipes/astropy-feedstock/pull/18)


[PKG-5631]: https://anaconda.atlassian.net/browse/PKG-5631?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ