### PR TITLE
astropy-iers-data 0.2025.1.13.0.34.51

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "astropy-iers-data" %}
-{% set version = "0.2024.9.2.0.33.23" %}
+{% set version = "0.2025.1.13.0.34.51" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
-  sha256: 50a5dade609ed6b9791a04f9da98184846b363e2fd0e36d62690c28c0a2c5114
+  sha256: de6fafd52088f589e2ef5bf797242965f3dfd77b667ea066f941fc98ddeda604
 
 build:
   skip: True  # [py<38]


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-6795](https://anaconda.atlassian.net/browse/PKG-6795)
- [Upstream repository](https://github.com/astropy/astropy-iers-data/tree/v0.2025.1.13.0.34.51)
- [Upstream changelog/diff](https://github.com/astropy/astropy-iers-data/compare/v0.2025.1.6.0.33.42...v0.2025.1.13.0.34.51)
- Relevant dependency PRs:
  - dependency for `astropy 7.0.0`

### Explanation of changes:

- Update version and sha


[PKG-6795]: https://anaconda.atlassian.net/browse/PKG-6795?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ