### PR TITLE
astropy-iers-data 0.2025.6.23.0.39.50

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@
 /build_artifacts
 
 *.pyc
+# Cursor temporary files
+/.cursor/tmp/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "astropy-iers-data" %}
-{% set version = "0.2025.1.13.0.34.51" %}
+{% set version = "0.2025.6.23.0.39.50" %}
 
 package:
   name: {{ name|lower }}
@@ -7,19 +7,18 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
-  sha256: de6fafd52088f589e2ef5bf797242965f3dfd77b667ea066f941fc98ddeda604
+  sha256: 3dd7cbf82408837ad21fb15db0c35d0bff19b1552f6b13de48542a246215a754
 
 build:
-  skip: True  # [py<38]
+  skip: true  # [py<38]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
 
 requirements:
   host:
     - python
-    - setuptools
-    - setuptools-scm
-    - wheel
+    - hatchling
+    - hatch-vcs
     - pip
   run:
     - python


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-8321](https://anaconda.atlassian.net/browse/PKG-8321) 
- [Upstream repo](https://github.com/astropy/astropy-iers-data/tree/v0.2025.6.23.0.39.50)
- release-diff: https://github.com/astropy/astropy-iers-data//compare/v0.2025.1.13.0.34.51...v0.2025.6.23.0.39.50
- requirements-tagged:
  - https://github.com/astropy/astropy-iers-data/blob/v0.2025.6.23.0.39.50/pyproject.toml


### Explanation of changes:

-

### Notes:

- The recipe has been updated by the `pi-cursor` tool. 

[PKG-8321]: https://anaconda.atlassian.net/browse/PKG-8321?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ