### PR TITLE
PKG-9337: astropy-iers-data 0.2025.8.25.0.36.58

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "astropy-iers-data" %}
-{% set version = "0.2025.6.23.0.39.50" %}
+{% set version = "0.2025.8.25.0.36.58" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
-  sha256: 3dd7cbf82408837ad21fb15db0c35d0bff19b1552f6b13de48542a246215a754
+  sha256: 7088ef4f28042b0bce4d5c48e84cc7726ea9d4520e3ec3bc7d368e989e5cb8f4
 
 build:
   skip: true  # [py<38]
@@ -32,7 +32,7 @@ test:
     - pip
 
 about:
-  home: https://github.com/astropy/astropy-iers-data/
+  home: https://github.com/astropy/astropy-iers-data
   summary: IERS Earth Rotation and Leap Second tables for the astropy core package
   description: |
     The iers package provides access to the tables provided by the International Earth Rotation
@@ -42,7 +42,7 @@ about:
   license_file: LICENSE.rst
   license_family: BSD
   doc_url: https://docs.astropy.org/en/latest/utils/iers.html
-  dev_url: https://github.com/astropy/astropy-iers-data/
+  dev_url: https://github.com/astropy/astropy-iers-data
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
astropy-iers-data 0.2025.8.25.0.36.58

**Destination channel:** defaults

### Links

- [PKG-9337](https://anaconda.atlassian.net/browse/PKG-9337) 
- [Upstream repository](https://github.com/astropy/astropy-iers-data/tree/v0.2025.8.25.0.36.58)

### Explanation of changes:

- new version update


[PKG-9337]: https://anaconda.atlassian.net/browse/PKG-9337?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ