### PR TITLE
astropy-iers-data 0.2025.12.8.0.38.44 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "astropy-iers-data" %}
-{% set version = "0.2025.11.24.0.39.11" %}
+{% set version = "0.2025.12.8.0.38.44" %}
 
 package:
   name: {{ name|lower }}
@@ -7,12 +7,12 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
-  sha256: de73939bf2aaae6ca1b8a62904ae93c50285d1ed7a6aeb6967b4f0d113f19afc
+  sha256: 8009f8d2ee0c08e4029a1e12251847ea2b176e3caba02d8ab07b49469d3dec86
 
 build:
-  skip: true  # [py<38]
-  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  skip: true  # [py<38]
 
 requirements:
   host:


### PR DESCRIPTION
astropy-iers-data 0.2025.12.8.0.38.44 

**Destination channel:** Defaults

### Links

- [PKG-11223]
- dev_url:        https://github.com/astropy/astropy-iers-data/tree/v0.2025.12.8.0.38.44
- conda_forge:    https://github.com/conda-forge/astropy-iers-data-feedstock
- pypi:           https://pypi.org/project/astropy-iers-data/0.2025.12.8.0.38.44
- pypi inspector: https://inspector.pypi.io/project/astropy-iers-data/0.2025.12.8.0.38.44

### Explanation of changes:

- new version number


[PKG-11223]: https://anaconda.atlassian.net/browse/PKG-11223?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ