### PR TITLE
astropy-iers-data 0.2026.1.19.0.42.31 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "astropy-iers-data" %}
-{% set version = "0.2026.1.5.0.43.43" %}
+{% set version = "0.2026.1.19.0.42.31" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
-  sha256: c0b28b8c29d60751d5d0008cda47537aadac2cb378be77a7c6bdb15d4c38b612
+  sha256: e389150579ce84da5f73ca47261ca5fed8e42652f28d6b034b6e9752a0b46e60
 
 build:
   number: 0


### PR DESCRIPTION
astropy-iers-data 0.2026.1.19.0.42.31 

**Destination channel:** Defaults

### Links

- [PKG-11875]
- dev_url:        https://github.com/astropy/astropy-iers-data/tree/v0.2026.1.19.0.42.31
- conda_forge:    https://github.com/conda-forge/astropy-iers-data-feedstock
- pypi:           https://pypi.org/project/astropy-iers-data/0.2026.1.19.0.42.31
- pypi inspector: https://inspector.pypi.io/project/astropy-iers-data/0.2026.1.19.0.42.31

### Explanation of changes:

- new version number


[PKG-11875]: https://anaconda.atlassian.net/browse/PKG-11875?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ