### PR TITLE
astropy-iers-data 0.2026.2.23.0.48.33

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "astropy-iers-data" %}
-{% set version = "0.2026.1.19.0.42.31" %}
+{% set version = "0.2026.2.23.0.48.33" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
-  sha256: e389150579ce84da5f73ca47261ca5fed8e42652f28d6b034b6e9752a0b46e60
+  sha256: ce331769003e55be76d5385c367a0acc42565462211c1fe3d5d22d37f0cdf284
 
 build:
   number: 0


### PR DESCRIPTION
**Destination channel:** Defaults

### Links

- [PKG-12435]
- dev_url:        https://github.com/astropy/astropy-iers-data/tree/v0.2026.2.23.0.48.33
- conda_forge:    https://github.com/conda-forge/astropy-iers-data-feedstock
- pypi:           https://pypi.org/project/astropy-iers-data/0.2026.2.23.0.48.33
- pypi inspector: https://inspector.pypi.io/project/astropy-iers-data/0.2026.2.23.0.48.33

### Explanation of changes:

- new version number

[PKG-12435]: https://anaconda.atlassian.net/browse/PKG-12435?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ