### PR TITLE
astropy-iers-data 0.2026.6.1.17.39.59 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "astropy-iers-data" %}
-{% set version = "0.2026.3.16.0.53.33" %}
+{% set version = "0.2026.6.1.17.39.59" %}
 
 package:
   name: {{ name|lower }}
@@ -7,12 +7,12 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
-  sha256: 8da3b6c56573cf63ec99c0e7b4ab74be7dc5af2aaa4a62fb671879f7411acbb6
+  sha256: a6976783e40a774f5aac417c0f5154c544728a44be17b27b05fae08b0d400e91
 
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  skip: true  # [py<38]
+  skip: true  # [py<310]
 
 requirements:
   host:


### PR DESCRIPTION
astropy-iers-data 0.2026.6.1.17.39.59 

**Destination channel:** Defaults

### Links

- [PKG-15006]
- dev_url:        https://github.com/astropy/astropy-iers-data/tree/v0.2026.6.1.17.39.59
- conda_forge:    https://github.com/conda-forge/astropy-iers-data-feedstock
- pypi:           https://pypi.org/project/astropy-iers-data/0.2026.6.1.17.39.59
- pypi inspector: https://inspector.pypi.io/project/astropy-iers-data/0.2026.6.1.17.39.59

### Explanation of changes:

- new version number


[PKG-15006]: https://anaconda.atlassian.net/browse/PKG-15006?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ